### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=See https://ez.analog.com/docs/DOC-2222 for tutorial
 category=Sensors
 url=http://annem.github.io/ADXL362/
 architectures=*
-includes=Arduino.h, SPI.h
+includes=ADXL362.h


### PR DESCRIPTION
The `includes` field in library.properties is used to customize which `#include` directives will be added to the sketch by the Arduino IDE via **Sketch > Include Library > ADXL362**. For this reason, the previous `includes` value was incorrect.

An #include directive for Arduino.h is already automatically added to the sketch by the Arduino IDE.

The `includes` field is only supported by Arduino IDE 1.6.10 and newer and those IDE versions do not require you to add `#include` directives for library dependencies so it is pointless to have SPI.h in the `includes` field.

What is needed in the `includes` field is ADXL362.h, which I have added in lieu of the unnecessary file names.